### PR TITLE
feat: move serde serialization behind the `serialize` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ rustc-hash = "1.1.0"
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = { version = "1.0.99", features = ["std"] }
 smallvec = { version ="1.11.0", features =  ["const_generics", "union", "serde"] }
+
+[features]
+serialize = []
+default = ["serialize"]

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -8,13 +8,15 @@ use crate::errors::PoastaError;
 
 pub mod messages {
     use petgraph::graph::IndexType;
+    #[cfg(feature = "serialize")]
     use serde::{Deserialize, Serialize};
     use crate::aligner::astar::AstarVisited;
     use crate::aligner::offsets::OffsetType;
     use crate::graphs::NodeIndexType;
     use crate::graphs::poa::POAGraph;
 
-    #[derive(Debug, Serialize, Deserialize)]
+    #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+    #[derive(Debug)]
     pub enum DebugOutputMessage {
         Empty,
         NewSequence { seq_name: String, sequence: String, max_rank: usize },

--- a/src/graphs/poa.rs
+++ b/src/graphs/poa.rs
@@ -7,6 +7,7 @@ use petgraph::{Incoming, Outgoing};
 use std::fmt::{Display, Formatter};
 
 use serde::de::DeserializeOwned;
+#[cfg(feature = "serialize")]
 use serde::{Deserialize, Serialize};
 
 use crate::aligner::alignment::{AlignedPair, Alignment};
@@ -17,7 +18,8 @@ use crate::io::graph::format_as_dot;
 /// A sequence aligned to the POA graph.
 ///
 /// Stores the sequence name and the start node in the graph.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone)]
 pub struct Sequence<N>(pub(crate) String, pub(crate) N)
 where
     N: NodeIndexType;
@@ -35,7 +37,8 @@ where
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Debug)]
 pub struct POANodeData<N>
 where
     N: NodeIndexType,
@@ -56,7 +59,8 @@ where
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Debug)]
 pub struct POAEdgeData {
     pub weight: usize,
     pub sequence_ids: Vec<usize>,
@@ -81,7 +85,8 @@ impl POAEdgeData {
 pub type POAGraphType<Ix> = StableDiGraph<POANodeData<NodeIndex<Ix>>, POAEdgeData, Ix>;
 pub(crate) type POANodeIndex<Ix> = <POAGraphType<Ix> as GraphBase>::NodeId;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Debug, Default)]
 pub struct POAGraph<Ix = u32>
 where
     Ix: PetgraphIndexType,
@@ -465,7 +470,7 @@ where
 }
 
 /// Wrapper with fixed node index types to make serialization to disk easier
-#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum POAGraphWithIx {
     U8(POAGraph<u8>),
     U16(POAGraph<u16>),

--- a/src/io/graph.rs
+++ b/src/io/graph.rs
@@ -2,7 +2,9 @@
 
 use std::collections::VecDeque;
 use std::fs::File;
-use std::io::{BufReader, Read, Write};
+#[cfg(feature = "serialize")]
+use std::io::Read;
+use std::io::{BufReader, Write};
 use std::path::Path;
 use std::{char, fmt};
 
@@ -19,12 +21,14 @@ use crate::errors::PoastaError;
 use crate::graphs::poa::{POAGraph, POAGraphWithIx, POANodeData, POANodeIndex, Sequence};
 use crate::graphs::AlignableRefGraph;
 
+#[cfg(feature = "serialize")]
 pub fn save_graph(graph: &POAGraphWithIx, out: impl Write) -> Result<(), PoastaError> {
     bincode::serialize_into(out, graph)?;
 
     Ok(())
 }
 
+#[cfg(feature = "serialize")]
 pub fn load_graph(reader: impl Read) -> Result<POAGraphWithIx, PoastaError> {
     let graph: POAGraphWithIx = bincode::deserialize_from(reader)?;
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,4 +1,6 @@
-pub mod graph;
 pub mod fasta;
+pub mod graph;
 
-pub use graph::{save_graph, load_graph, load_graph_from_fasta_msa};
+pub use graph::load_graph_from_fasta_msa;
+#[cfg(feature = "serialize")]
+pub use graph::{load_graph, save_graph};


### PR DESCRIPTION
### Changes
- A new feature flag called `serialize` is created inside `Cargo.toml`
- Structures and enums implement serialization and deserialization only when the feature is enabled
- This feature flag is enabled by default since the main CLI requires reading serialized data
- Upstream libraries can add `default-features = false` in their `Cargo.toml` while adding poasta as a dependency which will remove serialization and deserialization capabilities and gate the `save_graph` and `load_graph` functions